### PR TITLE
Fixes for Python script generator of st.cmd and for db definition files

### DIFF
--- a/htscope1/db/htscope1.db
+++ b/htscope1/db/htscope1.db
@@ -48,7 +48,7 @@ record(calcout, "$(PFX)$(UUT):PAN_LEFT:1:c") {
 	field(INPA, "$(PFX)$(UUT):DELAY")
 	field(CALC, "A-1")
 	field(OOPT, "Every Time")
-	field(DOPT, "use CALC")
+	field(DOPT, "Use CALC")
 	field(OUT,  "$(PFX)$(UUT):DELAY PP")
 	field(FLNK, "$(PFX)$(UUT):REFRESH PP")
 }
@@ -61,7 +61,7 @@ record(calcout, "$(PFX)$(UUT):PAN_RIGHT:1:c") {
 	field(INPA, "$(PFX)$(UUT):DELAY")
 	field(CALC, "A+1")
 	field(OOPT, "Every Time")
-	field(DOPT, "use CALC")
+	field(DOPT, "Use CALC")
 	field(OUT,  "$(PFX)$(UUT):DELAY PP")
 	field(FLNK, "$(PFX)$(UUT):REFRESH PP")
 }
@@ -74,7 +74,7 @@ record(calcout, "$(PFX)$(UUT):ZOOM:IN:c") {
 	field(INPA, "$(PFX)$(UUT):STRIDE")
 	field(CALC, "A/2")
 	field(OOPT, "Every Time")
-	field(DOPT, "use CALC")
+	field(DOPT, "Use CALC")
 	field(OUT,  "$(PFX)$(UUT):STRIDE PP")
 	field(FLNK, "$(PFX)$(UUT):REFRESH PP")
 }
@@ -87,7 +87,7 @@ record(calcout, "$(PFX)$(UUT):ZOOM:OUT:c") {
 	field(INPA, "$(PFX)$(UUT):STRIDE")
 	field(CALC, "A*2")
 	field(OOPT, "Every Time")
-	field(DOPT, "use CALC")
+	field(DOPT, "Use CALC")
 	field(OUT,  "$(PFX)$(UUT):STRIDE PP")
 	field(FLNK, "$(PFX)$(UUT):REFRESH PP")
 }

--- a/htscope1/db/htscope1_ch.db
+++ b/htscope1/db/htscope1_ch.db
@@ -1,8 +1,8 @@
 
 # make one
-record(waveform, "$(UUT):TB") {
+record(waveform, "$(PFX)$(UUT):TB") {
     field(DTYP, "asynFloat64ArrayIn")
-    field(INP,  "@asyn($(UUT),0,$(TIMEOUT))TIMEBASE")
+    field(INP,  "@asyn($(PFX)$(UUT),0,$(TIMEOUT))TIMEBASE")
     field(FTVL, "DOUBLE")
     field(NELM, "$(NPOINTS)")
     field(LOPR, "0")
@@ -13,9 +13,9 @@ record(waveform, "$(UUT):TB") {
 
 # make nchan
 
-record(waveform, "$(UUT):CH:$(CH)") {
+record(waveform, "$(PFX)$(UUT):CH:$(CH)") {
     field(DTYP, "asynFloat64ArrayIn")
-    field(INP,  "@asyn($(UUT),$(IX),$(TIMEOUT))CHANNEL")
+    field(INP,  "@asyn($(PFX)$(UUT),$(IX),$(TIMEOUT))CHANNEL")
     field(FTVL, "DOUBLE")
     field(NELM, "$(NPOINTS)")
     field(LOPR, "-10")

--- a/htscope1/db/htscope1_main.db
+++ b/htscope1/db/htscope1_main.db
@@ -19,6 +19,6 @@ record(bo, "$(PFX):RUNSTOP") {
 	field(DTYP, "Soft Channel")
 	field(ZNAM, "STOP")
 	field(ONAM, "RUN")
-	field(VAL,  "STOP")
 	field(PINI, "YES")
+    field(VAL, "0")
 }

--- a/htscope1/scripts/make_htscope_st.cmd.py
+++ b/htscope1/scripts/make_htscope_st.cmd.py
@@ -47,7 +47,7 @@ def print_postamble(args):
     maindb = "../../db/htscope1_main.db"
     uuts= ','.join(args.uuts)
     args.fp.write(f"""
-dbloadRecords("{maindb}","PFX={args.prefix},UUTS={uuts}")
+dbLoadRecords("{maindb}","PFX={args.prefix},UUTS={uuts}")
 """)
     args.fp.write("iocInit()\n")
     args.fp.write("# end\n")

--- a/htscope1/scripts/make_htscope_st.cmd.py
+++ b/htscope1/scripts/make_htscope_st.cmd.py
@@ -26,7 +26,7 @@ def print_uut(uut, args):
     wsize=4 if args.data32 == 1 else 2
     args.fp.write(f"\n# uut {uut}\n")
     args.fp.write(f"""
-multiChannelScopeConfigure("{uut}", {args.nchan}, {args.ndata}, {wsize})
+multiChannelScopeConfigure("{args.prefix}{uut}", {args.nchan}, {args.ndata}, {wsize})
     """)
     tm = "TIMEOUT=0"
     uutdb="../../db/htscope1.db"
@@ -39,7 +39,7 @@ dbLoadRecords("{uutdb}","PFX={args.prefix},UUT={uut},{tm}")
         args.fp.write(f"""
 dbLoadRecords("{chdb}","PFX={args.prefix},UUT={uut},CH={ch},IX={ix},{tm},NPOINTS={args.ndata}")""")
     args.fp.write(f"""
-asynSetTraceMask("{uut}",0,0xff))
+asynSetTraceMask("{args.prefix}{uut}",0,0xff))
     """)
 
 def print_postamble(args):


### PR DESCRIPTION
Fixes typos in generated st.cmd and db files.

Adds prefixes for fully resolved names where required.